### PR TITLE
fix(serverless): rename prod kleros liquid that was too long

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -66,7 +66,7 @@ functions:
           Action: ['dynamodb:GetItem'],
           Resource: 'arn:aws:dynamodb:us-east-2:547511976516:table/user-settings',
         }
-  postEventHandlersKlerosLiquidEmails:
+  postKlerosLiquid:
     handler: src/event-handlers/kleros-liquid-emails.post
     events:
       - {
@@ -81,7 +81,7 @@ functions:
       INFURA_URL: '${self:custom.kmsSecrets.secrets.${self:custom.environments.${self:provider.stage}}_INFURA_URL}'
       KLEROS_LIQUID_ADDRESS: '${self:custom.kmsSecrets.secrets.${self:custom.environments.${self:provider.stage}}_KLEROS_LIQUID_ADDRESS}'
       SENDGRID_API_KEY: '${self:custom.kmsSecrets.secrets.SENDGRID_API_KEY}'
-    iamRoleStatementsName: 'postEventHandlersKlerosLiquidEmails-${self:provider.stage}-lambda-role'
+    iamRoleStatementsName: 'postKlerosLiquid-${self:provider.stage}-lambda-role'
     iamRoleStatements:
       - {
           Effect: Allow,


### PR DESCRIPTION
- Shorten name that was too long to deploy in production