### PR TITLE
fix: shorten poh handler

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -201,7 +201,7 @@ functions:
           Action: ['dynamodb:GetItem'],
           Resource: 'arn:aws:dynamodb:us-east-2:547511976516:table/user-settings',
         }
-  postTromazoHandlersProofOfHumanity:
+  postTromazoHandlersPOH:
     handler: src/tromazo-handlers/proof-of-humanity.post
     events:
       - {
@@ -218,7 +218,7 @@ functions:
       SENDGRID_API_KEY: '${self:custom.kmsSecrets.secrets.SENDGRID_API_KEY}'
       PROOF_OF_HUMANITY_SUBGRAPH_URL: '${self:custom.kmsSecrets.secrets.${self:custom.environments.${self:provider.stage}}_PROOF_OF_HUMANITY_SUBGRAPH_URL}'
       PROOF_OF_HUMANITY_CONTRACT_ADDRESS: '${self:custom.kmsSecrets.secrets.${self:custom.environments.${self:provider.stage}}_PROOF_OF_HUMANITY_CONTRACT_ADDRESS}'
-    iamRoleStatementsName: 'postTromazoHandlersProofOfHumanity-${self:provider.stage}-lambda-role'
+    iamRoleStatementsName: 'postTromazoHandlersPOH-${self:provider.stage}-lambda-role'
     iamRoleStatements:
       - {
           Effect: Allow,


### PR DESCRIPTION
AWS limits function names to 64 characters and `event-microservices-production-postTromazoHandlersProofOfHumanity` was too long.